### PR TITLE
feat: add middleware to protect dashboard routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+
+const isProtectedRoute = createRouteMatcher([
+  '/dashboard(.*)',
+]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+});
+
+export const config = {
+  matcher: [
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/(api|trpc)(.*)',
+  ],
+};


### PR DESCRIPTION
Implements route protection for /dashboard and all subpages using Clerk middleware. This provides better performance than component-level protection.

Fixes #4